### PR TITLE
Fix saves being disabled when they shouldn't

### DIFF
--- a/src/game/server/gameinterface.cpp
+++ b/src/game/server/gameinterface.cpp
@@ -875,8 +875,10 @@ void UpdateSavesDisabledCallback( IConVar *pConVar, const char *pOldString, floa
 	ConVarRef save_disable("save_disable");
 	if (save_disable.IsValid() && map_disable.IsValid())
 	{
-		int mapDisableBit = map_disable.GetInt() << 1;
-		save_disable.SetValue( save_disable.GetInt() | mapDisableBit );
+		if (map_disable.GetBool())
+			save_disable.SetValue( save_disable.GetInt() | 0x2 );
+		else
+			save_disable.SetValue( save_disable.GetInt() & ~0x2 );
 	}
 }
 
@@ -1509,6 +1511,10 @@ bool CServerGameDLL::LevelInit( const char *pMapName, char const *pMapEntities, 
 
 	// ask for the latest game rules
 	GameRules()->UpdateGameplayStatsFromSteam();
+
+	// in the CSGO code this only happens when transitioning, unsure why
+	// it seems to be done on new game and save/load in other places anyway
+	map_wants_save_disable.SetValue( 0 );
 
 	return true;
 }


### PR DESCRIPTION
In #9 I implemented `map_wants_save_disable` using a hack where I store its value in the second bit of `save_disable`, which the engine then reads. Well, turns out I did this completely wrong and apparently no one ever noticed, resulting in saves being disabled almost all the time. This PR fixes it to now function correctly.